### PR TITLE
Row Generator fixes

### DIFF
--- a/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
+++ b/compatibility-client/src/main/java/com/vaadin/v7/client/ui/VScrollTable.java
@@ -7017,7 +7017,8 @@ public class VScrollTable extends FlowPanel
                             addSpannedCell(uidl, cell.toString(), aligns[0], "",
                                     htmlContentAllowed, false, null, colCount);
                         } else {
-                            addSpannedCell(uidl, (Widget) cell, aligns[0], "",
+                            final ComponentConnector cellContent = client.getPaintable((UIDL) cell);
+                            addSpannedCell(uidl, cellContent.getWidget(), aligns[0], "",
                                     false, colCount);
                         }
                         break;


### PR DESCRIPTION
Hi,

this PR fixes following issues in row generator feature (https://vaadin.com/api/framework/7.7.17/com/vaadin/ui/Table.RowGenerator.html):

1. Class Cast exception on client side when rendering components in generated rows (https://github.com/vaadin/framework/issues/2360)
2. "Widget is still attached to the DOM after the connector ... has been unregistered. Widget was removed" errors, caused by superfluous calls of RowGenerator#generateRow method in com.vaadin.v7.ui.Table#parseItemIdToCells

